### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe HTML constructed from library input

### DIFF
--- a/apps/moon_live_view/assets/js/utils/generateSvgIcon.js
+++ b/apps/moon_live_view/assets/js/utils/generateSvgIcon.js
@@ -1,20 +1,44 @@
+// Only allows safe icon names: alphanumeric, dash, underscore.
+function sanitizeIconName(name) {
+  const SAFE_ICON_RE = /^[a-zA-Z0-9_\-]+$/;
+  return SAFE_ICON_RE.test(name) ? name : '';
+}
+
+// Only allows iconPath with safe path segments (no '..', '<', '>', etc).
+function sanitizeIconPath(iconPath) {
+  // We'll allow empty string or safe path fragments.
+  const SAFE_PATH_RE = /^[a-zA-Z0-9_\-\/]+$/;
+  return SAFE_PATH_RE.test(iconPath) ? iconPath : '';
+}
+
 const generateSvgIcon = (name, iconPath = "") => {
   const fragment = document.createDocumentFragment();
 
-  if (!name) {
+  // Sanitize input
+  const safeName = sanitizeIconName(name);
+  const safeIconPath = sanitizeIconPath(iconPath);
+
+  if (!safeName) {
     return fragment;
   }
 
-  const iconUrl = iconPath
-    ? `${iconPath}/${name}.svg#${name}`
-    : `/moon_live_view/icons/${name}.svg#${name}`;
+  const iconUrl = safeIconPath
+    ? `${safeIconPath}/${safeName}.svg#${safeName}`
+    : `/moon_live_view/icons/${safeName}.svg#${safeName}`;
 
-  const template = document.createElement("template");
-  template.innerHTML = `<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <use href="${iconUrl}"></use>
-  </svg>`;
+  // Instead of innerHTML, create elements safely:
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("width", "20");
+  svg.setAttribute("height", "20");
+  svg.setAttribute("viewBox", "0 0 20 20");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
 
-  return fragment.appendChild(template.content.firstElementChild);
+  const use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+  use.setAttribute("href", iconUrl);
+  svg.appendChild(use);
+
+  return fragment.appendChild(svg);
 };
 
 export default generateSvgIcon;


### PR DESCRIPTION
Potential fix for [https://github.com/coingaming/moon-live-view/security/code-scanning/2](https://github.com/coingaming/moon-live-view/security/code-scanning/2)

To fix the vulnerability, we should sanitize the `name` and `iconPath` arguments before using them in the SVG construction. Since the risk is primarily of injecting unwanted HTML, attribute, or JavaScript URIs, escaping or whitelisting allowed icon names is best. 

The simplest robust solution is:
- Only allow icon names to consist of a safe subset of characters (e.g., alphanumeric plus dash and underscore).
- Optionally, use DOM APIs (`setAttribute`) instead of constructing HTML strings with interpolation.
- If the icons are all known within your app, consider a whitelist.

Implementation steps:
1. Add a function (in `apps/moon_live_view/assets/js/utils/generateSvgIcon.js`) to validate/sanitize the `name` and `iconPath`.
2. Replace construction of the SVG markup via `innerHTML` with safe, programmatic element creation and `setAttribute`, which avoids HTML parsing with tainted data.
3. Only update the file(s) shown in the snippets, so changes will be localized to `generateSvgIcon.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
